### PR TITLE
rm metawiki

### DIFF
--- a/src/main/resources/wikis.txt
+++ b/src/main/resources/wikis.txt
@@ -1,6 +1,5 @@
 # wikimedia
 wikimedia	commons			https://commons.wikimedia.org/w/api.php
-wikimedia	meta			https://meta.wikimedia.org/w/api.php
 
 # wikibooks
 wikibooks	de				https://de.wikibooks.org/w/api.php


### PR DESCRIPTION
upload on metawiki was closed (upload only by uploaders) - no need to massupload there
