### PR TITLE
[i18n] Update image_wikimedia_commons.bpp

### DIFF
--- a/src/main/resources/image_wikimedia_commons.bpp
+++ b/src/main/resources/image_wikimedia_commons.bpp
@@ -23,7 +23,7 @@ $(upload.description)
 $(upload.coordinates)
 # }
 # if (!common.licenseTemplate.equals("")) {
-== {{int:license}} ==
+== {{int:license-header}} ==
 $(common.licenseTemplate)
 # }
 $(common.categories)


### PR DESCRIPTION
Proper internationalization per [example](https://commons.wikimedia.org/w/index.php?title=File%3AAutomatisches_Zeichengeraet_ZUSE_Z64_ubt.JPG&diff=123219860&oldid=122269943).
