### PR TITLE
Add "others" field for others templates

### DIFF
--- a/src/main/resources/image_default.bpp
+++ b/src/main/resources/image_default.bpp
@@ -31,6 +31,9 @@ $(common.author)
 == permission ==
 $(common.permission)
 
+== others ==
+$(common.others)
+
 == license ==
 $(common.licenseDescription)
 $(common.licenseTemplate)

--- a/src/main/resources/image_wikimedia_commons.bpp
+++ b/src/main/resources/image_wikimedia_commons.bpp
@@ -22,6 +22,9 @@ $(upload.description)
 # else if (!upload.coordinates.equals("")) {
 $(upload.coordinates)
 # }
+# if (!common.others.equals("")) {
+$(common.others)
+# }
 # if (!common.licenseTemplate.equals("")) {
 == {{int:license-header}} ==
 $(common.licenseTemplate)

--- a/src/main/resources/messages_default.properties
+++ b/src/main/resources/messages_default.properties
@@ -10,6 +10,7 @@ common.source=source
 common.date=date
 common.author=author
 common.permission=permission
+common.others=others
 common.categories=categories
 common.license=license
 common.categories.tooltip='|' separated list without "Category:"-prefix

--- a/src/main/scala/commonist/data/CommonData.scala
+++ b/src/main/scala/commonist/data/CommonData.scala
@@ -10,6 +10,7 @@ case class CommonData(
 	source:String,
 	author:String,
 	permission:String,
+	others:String,
 	license:LicenseData,
 	categories:String
 )

--- a/src/main/scala/commonist/task/UploadFilesTask.scala
+++ b/src/main/scala/commonist/task/UploadFilesTask.scala
@@ -53,6 +53,7 @@ final class UploadFilesTask(
 				commonData.source.trim,
 				commonData.author.trim,
 				commonData.permission.trim,
+				commonData.others.trim,
 				commonData.license.template,
 				commonData.license.description,
 				Parser parseCategories commonData.categories

--- a/src/main/scala/commonist/task/upload/TemplateData.scala
+++ b/src/main/scala/commonist/task/upload/TemplateData.scala
@@ -10,6 +10,7 @@ case class Common(
 	@BeanProperty source:String,
 	@BeanProperty author:String,
 	@BeanProperty permission:String,
+	@BeanProperty others:String,
 	@BeanProperty licenseTemplate:String,
 	@BeanProperty licenseDescription:String,
 	@BeanProperty categories:String

--- a/src/main/scala/commonist/ui/CommonUI.scala
+++ b/src/main/scala/commonist/ui/CommonUI.scala
@@ -34,6 +34,7 @@ final class CommonUI(wikiList:ISeq[WikiData], licenseList:ISeq[LicenseData]) ext
 	private val dateLabel			= new JLabel(Messages text "common.date",			SwingConstants.RIGHT)
 	private val authorLabel			= new JLabel(Messages text "common.author",			SwingConstants.RIGHT)
 	private val permissionLabel		= new JLabel(Messages text "common.permission",		SwingConstants.RIGHT)
+	private val othersLabel		    = new JLabel(Messages text "common.others", 		SwingConstants.RIGHT)
 	private val categoriesLabel		= new JLabel(Messages text "common.categories",		SwingConstants.RIGHT)
 	private val licenseLabel		= new JLabel(Messages text "common.license",		SwingConstants.RIGHT)
 	
@@ -47,6 +48,7 @@ final class CommonUI(wikiList:ISeq[WikiData], licenseList:ISeq[LicenseData]) ext
 	private val dateEditor			= new JTextField(Constants.INPUT_FIELD_WIDTH) with TextComponentUndo
 	private val authorEditor		= new JTextField(Constants.INPUT_FIELD_WIDTH) with TextComponentUndo
 	private val permissionEditor	= new JTextField(Constants.INPUT_FIELD_WIDTH) with TextComponentUndo
+	private val othersEditor	    = new JTextField(Constants.INPUT_FIELD_WIDTH) with TextComponentUndo
 	private val categoriesEditor	= new JTextField(Constants.INPUT_FIELD_WIDTH) with TextComponentUndo
 	private val licenseEditor		= new JComboBox(licenseList.toArray[Object]) {
 		override def getPreferredSize():Dimension =
@@ -126,14 +128,17 @@ final class CommonUI(wikiList:ISeq[WikiData], licenseList:ISeq[LicenseData]) ext
 	add(permissionLabel, 	GBC pos (0,9) size (1,1) weight (0,0) anchor EAST		fill NONE		insetsTLBR (0,4,0,4))
 	add(permissionEditor,	GBC pos (1,9) size (1,1) weight (1,0) anchor WEST		fill HORIZONTAL	insetsTLBR (0,0,0,0))
 	
-	add(categoriesLabel,	GBC pos (0,10) size (1,1) weight (0,0) anchor NORTHEAST	fill NONE		insetsTLBR (0,4,0,4))
-	add(categoriesEditor,	GBC pos (1,10) size (1,1) weight (0,0) anchor WEST		fill HORIZONTAL	insetsTLBR (0,0,0,0))
+	add(othersLabel,	 	GBC pos (0,10) size (1,1) weight (0,0) anchor EAST		fill NONE		insetsTLBR (0,4,0,4))
+	add(othersEditor,		GBC pos (1,10) size (1,1) weight (1,0) anchor WEST		fill HORIZONTAL	insetsTLBR (0,0,0,0))
 
-	add(licenseLabel,		GBC pos (0,11) size (1,1) weight (0,0) anchor EAST		fill NONE		insetsTLBR (0,4,0,4))
-	add(licenseEditor,		GBC pos (1,11) size (1,1) weight (0,0) anchor WEST		fill HORIZONTAL	insetsTLBR (0,0,0,0))
+	add(categoriesLabel,	GBC pos (0,11) size (1,1) weight (0,0) anchor NORTHEAST	fill NONE		insetsTLBR (0,4,0,4))
+	add(categoriesEditor,	GBC pos (1,11) size (1,1) weight (0,0) anchor WEST		fill HORIZONTAL	insetsTLBR (0,0,0,0))
+
+	add(licenseLabel,		GBC pos (0,12) size (1,1) weight (0,0) anchor EAST		fill NONE		insetsTLBR (0,4,0,4))
+	add(licenseEditor,		GBC pos (1,12) size (1,1) weight (0,0) anchor WEST		fill HORIZONTAL	insetsTLBR (0,0,0,0))
 
 	// separator 2
-	add(separator2,			GBC pos (0,12) size (2,1) weight (1,0) anchor CENTER fill HORIZONTAL	insetsTLBR (0,0,0,0))
+	add(separator2,			GBC pos (0,13) size (2,1) weight (1,0) anchor CENTER fill HORIZONTAL	insetsTLBR (0,0,0,0))
 	
 	/** gets all data edit in this UI */
 	def getData:CommonData =
@@ -146,6 +151,7 @@ final class CommonUI(wikiList:ISeq[WikiData], licenseList:ISeq[LicenseData]) ext
 				sourceEditor.getText,
 				authorEditor.getText,
 				permissionEditor.getText,
+				othersEditor.getText,
 				licenseEditor.getSelectedItem match {
 					case x:String		=> LicenseData(x, "")
 					case x:LicenseData	=> x
@@ -165,6 +171,7 @@ final class CommonUI(wikiList:ISeq[WikiData], licenseList:ISeq[LicenseData]) ext
 		sourceEditor		setText (settings getOrElse ("sourceEditor.Text",		""))
 		dateEditor			setText (settings getOrElse ("dateEditor.Text",			""))
 		permissionEditor	setText (settings getOrElse ("permissionEditor.Text",	""))
+		othersEditor		setText (settings getOrElse ("othersEditor.Text",		""))
 		authorEditor		setText (settings getOrElse ("authorEditor.Text",		""))
 		categoriesEditor	setText (settings getOrElse ("categoriesEditor.Text",	""))
 		
@@ -188,6 +195,7 @@ final class CommonUI(wikiList:ISeq[WikiData], licenseList:ISeq[LicenseData]) ext
 		settings set ("dateEditor.Text",			dateEditor.getText)
 		settings set ("authorEditor.Text",			authorEditor.getText)
 		settings set ("permissionEditor.Text",		permissionEditor.getText)
+		settings set ("othersEditor.Text",			othersEditor.getText)
 		settings set ("categoriesEditor.Text",		categoriesEditor.getText)
 		
 		val wikiData	= wikiEditor.getSelectedItem.asInstanceOf[WikiData]


### PR DESCRIPTION
As a commonist user, I've always found it lacked a "free text" field. I usually upload files "Supported by" and I cannot set the template on upload.

This others field permits the user to set a "free text" on a file, that will appears under the {{information}} template