### PR TITLE
Allow to generate TIFF thumbnails

### DIFF
--- a/src/main/scala/commonist/thumb/Thumbnails.scala
+++ b/src/main/scala/commonist/thumb/Thumbnails.scala
@@ -72,7 +72,7 @@ final class Thumbnails(cache:FileCache) extends Logging {
 		// TYPE_BYTE_INDEXED	works, but inverts color if converted to TYPE_3BYTE_BGR
 		
 		// normalize image type
-		val normalizeTypes	= Set(BufferedImage.TYPE_3BYTE_BGR, BufferedImage.TYPE_BYTE_INDEXED)
+		val normalizeTypes	= Set(BufferedImage.TYPE_3BYTE_BGR, BufferedImage.TYPE_BYTE_INDEXED, BufferedImage.TYPE_CUSTOM)
 		val image2 =
 				if (normalizeTypes contains image.getType) {
 					val normalized	= new BufferedImage(


### PR DESCRIPTION
When running Commonist with Java 9+ we can natively load TIFF files. However the thumbails are not generated, because they have TYPE_CUSTOM as image type, and this special value cannot be used to create a new image.

This PR fixes the problem and allows TIFF files to get a thumbnail.